### PR TITLE
VRMモデル名を設定ファイルで指定する機能の追加

### DIFF
--- a/Player2VRM/Player2VRM.cs
+++ b/Player2VRM/Player2VRM.cs
@@ -240,7 +240,7 @@ namespace Player2VRM
                 }
                 catch
                 {
-                    if(pathStr != null)
+                    if(ModelStr != null)
                         UnityEngine.Debug.LogWarning("VRMファイルの読み込みに失敗しました。settings.txt内のModelNameを確認してください。");
                     else
                         UnityEngine.Debug.LogWarning("VRMファイルの読み込みに失敗しました。Player2VRMフォルダにplayer.vrmを配置してください。");

--- a/Player2VRM/Player2VRM.cs
+++ b/Player2VRM/Player2VRM.cs
@@ -228,7 +228,11 @@ namespace Player2VRM
         {
             if (vrmModel == null)
             {
+                //カスタムモデル名の取得(設定ファイルにないためLogの出力が不自然にならないよう調整)
+                var ModelStr = Settings.ReadSettings("ModelName");
                 var path = Environment.CurrentDirectory + @"\Player2VRM\player.vrm";
+                if (ModelStr != null)
+                    path = Environment.CurrentDirectory + @"\Player2VRM\" + ModelStr + ".vrm";
 
                 try
                 {
@@ -236,7 +240,10 @@ namespace Player2VRM
                 }
                 catch
                 {
-                    UnityEngine.Debug.LogWarning("VRMファイルの読み込みに失敗しました。Player2VRMフォルダにplayer.vrmを配置してください。");
+                    if(pathStr != null)
+                        UnityEngine.Debug.LogWarning("VRMファイルの読み込みに失敗しました。settings.txt内のModelNameを確認してください。");
+                    else
+                        UnityEngine.Debug.LogWarning("VRMファイルの読み込みに失敗しました。Player2VRMフォルダにplayer.vrmを配置してください。");
                     return;
                 }
 


### PR DESCRIPTION
タイトルの通りです。
settings.txt内に以下のような形で記述し、起動した場合に`player.vrm`に代わって`mecchakawaiiavatar.vrm`が読み込まれるものです。
これにより複数のVRMアバターを使用していた場合でも元のファイル名を汚すことなくアバターを変更することができるようになります。
```
ModelName=mecchakawaiiavatar
```

