### PR TITLE
add Arrow drawing setting

### DIFF
--- a/Player2VRM/Player2VRM.cs
+++ b/Player2VRM/Player2VRM.cs
@@ -265,6 +265,27 @@ namespace Player2VRM
                     return true;
                 }
             }
+            
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(OcAccessoryCtrl))]
+    [HarmonyPatch("setAf_DrawFlag")]
+    static class OcAccessoryCtrlVRM
+    {
+        static bool Prefix(OcAccessoryCtrl __instance, OcAccessoryCtrl.AccType type)
+        {
+
+            if (type == OcAccessoryCtrl.AccType.Quiver)
+            {
+                var str = Settings.ReadSettings("DrawEquipArrow");
+                var flag = true;
+                if (bool.TryParse(str, out flag))
+                {
+                    return false;
+                }
+            }
             return true;
         }
     }


### PR DESCRIPTION
矢を装備時に背負った矢筒の非表示設定を追加します。
すいません、盾の時に一緒にやるべきでした…！

// 矢を描画するかどうか true:描画 false:描画しない
DrawEquipArrow=true